### PR TITLE
Create Date objects with correct months

### DIFF
--- a/lib/org-mode-parser.js
+++ b/lib/org-mode-parser.js
@@ -460,17 +460,17 @@ var parseBigString=function (data){
                 if(scheduledStuff){
                     //debug("Matched:"+line);
                     // new Date(year, month, day, hours, minutes, seconds, ms)
-                    sched_date= new Date(scheduledStuff[1], scheduledStuff[2],scheduledStuff[3],
+                    sched_date= new Date(scheduledStuff[1], scheduledStuff[2] - 1,scheduledStuff[3],
                                          0,0,0,0);
                 }
                 var deadlineStuff=line.match(deadlineRE);
                 if(deadlineStuff){
-                    deadline_date= new Date(deadlineStuff[1], deadlineStuff[2],deadlineStuff[3],
+                    deadline_date= new Date(deadlineStuff[1], deadlineStuff[2] - 1,deadlineStuff[3],
                                             0,0,0,0);
                 }
                 var closedStuff=line.match(closedRE);
                 if(closedStuff){
-                    closed_date= new Date(closedStuff[1], closedStuff[2],closedStuff[3],
+                    closed_date= new Date(closedStuff[1], closedStuff[2] - 1,closedStuff[3],
                                             0,0,0,0);
                 }
                 if(isAClockLine){


### PR DESCRIPTION
JavaScript's `Date` class expects `month` to be 0-11.